### PR TITLE
Update for new pythonjsonlogger

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.8.2
+  rev: v0.8.3
   hooks:
   # Run the linter.
   - id: ruff

--- a/annotated_logger/__init__.py
+++ b/annotated_logger/__init__.py
@@ -109,7 +109,7 @@ DEFAULT_LOGGING_CONFIG = {
     },
     "formatters": {
         "annotated_formatter": {
-            "class": "pythonjsonlogger.jsonlogger.JsonFormatter",  # pragma: no mutate
+            "class": "pythonjsonlogger.json.JsonFormatter",  # pragma: no mutate
             "format": "{created} {levelname} {name} {message}",  # pragma: no mutate
             "style": "{",
         },

--- a/annotated_logger/__init__.py
+++ b/annotated_logger/__init__.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # https://test.pypi.org/project/annotated-logger/
 # The dev versions in testpypi can then be pulled in to whatever project needed
 # the new feature.
-VERSION = "1.2.1"  # pragma: no mutate
+VERSION = "1.2.2.dev0"  # pragma: no mutate
 
 T = TypeVar("T")
 P = ParamSpec("P")

--- a/annotated_logger/__init__.py
+++ b/annotated_logger/__init__.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # https://test.pypi.org/project/annotated-logger/
 # The dev versions in testpypi can then be pulled in to whatever project needed
 # the new feature.
-VERSION = "1.2.2.dev0"  # pragma: no mutate
+VERSION = "1.2.2"  # pragma: no mutate
 
 T = TypeVar("T")
 P = ParamSpec("P")

--- a/example/logging_config.py
+++ b/example/logging_config.py
@@ -93,7 +93,7 @@ LOGGING = {
     },
     "formatters": {
         "logging_config.annotated_formatter": {
-            "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
+            "class": "pythonjsonlogger.json.JsonFormatter",
             # Note that this format string uses `time` which is set by the renamer
             # plugin. It also has `lvl` which is there strictly to test our fallback
             # to using `levelno` in the mocks to determine level.
@@ -116,7 +116,7 @@ LOGGING = {
             "style": "{",
         },
         "logging_config.weird_formatter": {
-            "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
+            "class": "pythonjsonlogger.json.JsonFormatter",
             "format": "{time} {lvl} {name} {message}",
             "style": "{",
         },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 ]
 dependencies = [
   "makefun",
-  "python-json-logger",
+  "python-json-logger>=3.1.0",
   "requests",
   # The mock makes use of this, but we really should separate the mock out into it's own package
   # That would allow the mock to be included in dev, not in prod

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ makefun==1.15.6
     # via hatch.envs.default
 pychoir==0.0.27
     # via hatch.envs.default
-python-json-logger==2.0.7
+python-json-logger==3.2.0
     # via hatch.envs.default
 requests==2.32.3
     # via hatch.envs.default

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -16,7 +16,7 @@
 # - typing_extensions
 # - makefun
 # - pychoir
-# - python-json-logger
+# - python-json-logger>=3.1.0
 # - requests
 #
 
@@ -95,7 +95,7 @@ pytest==8.3.4
     #   pytest-randomly
 pytest-cov==6.0.0
     # via hatch.envs.dev
-pytest-freezer==0.4.8
+pytest-freezer==0.4.9
     # via hatch.envs.dev
 pytest-github-actions-annotate-failures==0.2.0
     # via hatch.envs.dev
@@ -105,7 +105,7 @@ pytest-randomly==3.16.0
     # via hatch.envs.dev
 python-dateutil==2.9.0.post0
     # via freezegun
-python-json-logger==2.0.7
+python-json-logger==3.2.0
     # via hatch.envs.dev
 pyyaml==6.0.2
     # via pre-commit
@@ -117,7 +117,7 @@ requests-mock==1.12.1
     # via hatch.envs.dev
 rich==13.9.4
     # via textual
-ruff==0.8.2
+ruff==0.8.3
     # via hatch.envs.dev
 setproctitle==1.3.4
     # via mutmut
@@ -125,7 +125,7 @@ six==1.17.0
     # via
     #   junit-xml
     #   python-dateutil
-textual==0.89.1
+textual==1.0.0
     # via mutmut
 toml==0.10.2
     # via mutmut


### PR DESCRIPTION
`python-json-logger` has a new major version update and moved one of it's classes that was used. This sets the requirement to the version that changed the path and updates to use the new path.