### PR TITLE
Run ruff and pyright on pushes to main so tags can require those checks.

### DIFF
--- a/.github/workflows/pyright.yaml
+++ b/.github/workflows/pyright.yaml
@@ -2,6 +2,8 @@ name: Pyright
 
 on:
   pull_request:
+  push:
+  branches: [ main ]
 
 jobs:
   pyright:

--- a/.github/workflows/pyright.yaml
+++ b/.github/workflows/pyright.yaml
@@ -3,7 +3,7 @@ name: Pyright
 on:
   pull_request:
   push:
-  branches: [ main ]
+    branches: [ main ]
 
 jobs:
   pyright:

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -2,6 +2,8 @@ name: Ruff
 
 on:
   pull_request:
+  push:
+    branches: [ main ]
 
 jobs:
   ruff:


### PR DESCRIPTION
The rules for tags are looking for `Coverage`, `ruff, and `pyright, but ruff and pyright aren't configured to run on pushes to main. They'll have passed in the PR, but the tag should be a commit reference in main, so they need to run there as well.