### PR TITLE
Dependency bump

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.8.3
+  rev: v0.8.6
   hooks:
   # Run the linter.
   - id: ruff

--- a/annotated_logger/__init__.py
+++ b/annotated_logger/__init__.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # https://test.pypi.org/project/annotated-logger/
 # The dev versions in testpypi can then be pulled in to whatever project needed
 # the new feature.
-VERSION = "1.2.2"  # pragma: no mutate
+VERSION = "1.2.3"  # pragma: no mutate
 
 T = TypeVar("T")
 P = ParamSpec("P")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,11 @@
 #
 # - makefun
 # - pychoir
-# - python-json-logger
+# - python-json-logger>=3.1.0
 # - requests
 #
 
-certifi==2024.8.30
+certifi==2024.12.14
     # via requests
 charset-normalizer==3.4.0
     # via requests
@@ -17,9 +17,9 @@ makefun==1.15.6
     # via hatch.envs.default
 pychoir==0.0.27
     # via hatch.envs.default
-python-json-logger==3.2.0
+python-json-logger==3.2.1
     # via hatch.envs.default
 requests==2.32.3
     # via hatch.envs.default
-urllib3==2.2.3
+urllib3==2.3.0
     # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 
 certifi==2024.12.14
     # via requests
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 idna==3.10
     # via requests

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -24,11 +24,11 @@ certifi==2024.12.14
     # via requests
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via mutmut
-coverage==7.6.9
+coverage==7.6.10
     # via
     #   hatch.envs.dev
     #   pytest-cov
@@ -40,7 +40,7 @@ filelock==3.16.1
     # via virtualenv
 freezegun==1.5.1
     # via pytest-freezer
-identify==2.6.3
+identify==2.6.5
     # via pre-commit
 idna==3.10
     # via requests
@@ -81,7 +81,7 @@ pre-commit==4.0.1
     # via hatch.envs.dev
 pychoir==0.0.27
     # via hatch.envs.dev
-pygments==2.18.0
+pygments==2.19.1
     # via rich
 pyright==1.1.391
     # via hatch.envs.dev
@@ -117,7 +117,7 @@ requests-mock==1.12.1
     # via hatch.envs.dev
 rich==13.9.4
     # via textual
-ruff==0.8.4
+ruff==0.8.6
     # via hatch.envs.dev
 setproctitle==1.3.4
     # via mutmut
@@ -143,5 +143,5 @@ uc-micro-py==1.0.3
     # via linkify-it-py
 urllib3==2.3.0
     # via requests
-virtualenv==20.28.0
+virtualenv==20.28.1
     # via pre-commit

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -20,13 +20,13 @@
 # - requests
 #
 
-certifi==2024.8.30
+certifi==2024.12.14
     # via requests
 cfgv==3.4.0
     # via pre-commit
 charset-normalizer==3.4.0
     # via requests
-click==8.1.7
+click==8.1.8
     # via mutmut
 coverage==7.6.9
     # via
@@ -83,7 +83,7 @@ pychoir==0.0.27
     # via hatch.envs.dev
 pygments==2.18.0
     # via rich
-pyright==1.1.390
+pyright==1.1.391
     # via hatch.envs.dev
 pytest==8.3.4
     # via
@@ -105,7 +105,7 @@ pytest-randomly==3.16.0
     # via hatch.envs.dev
 python-dateutil==2.9.0.post0
     # via freezegun
-python-json-logger==3.2.0
+python-json-logger==3.2.1
     # via hatch.envs.dev
 pyyaml==6.0.2
     # via pre-commit
@@ -117,7 +117,7 @@ requests-mock==1.12.1
     # via hatch.envs.dev
 rich==13.9.4
     # via textual
-ruff==0.8.3
+ruff==0.8.4
     # via hatch.envs.dev
 setproctitle==1.3.4
     # via mutmut
@@ -141,7 +141,7 @@ typing-extensions==4.12.2
     #   textual
 uc-micro-py==1.0.3
     # via linkify-it-py
-urllib3==2.2.3
+urllib3==2.3.0
     # via requests
 virtualenv==20.28.0
     # via pre-commit


### PR DESCRIPTION
#36 also bumps `junit-xml`, which breaks the `mutmut` dependency. Not sure why dependabot didn't realize that. This bumps the other dependencies.