### PR TITLE
Migrate Away from Container Builder Token

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ registries:
     type: docker-registry
     url: ghcr.io
     username: PAT
-    password: ${{secrets.CONTAINER_BUILDER_TOKEN}}
+    password: ${{secrets.BASE_CONTAINER_IMAGE_READER_DEPENDABOT}}
 updates:
 - package-ecosystem: github-actions
   directory: "/"


### PR DESCRIPTION
# Contents
In accordance with the [impending migration away from `CONTAINER_BUILDER_TOKEN`](https://thehub.github.com/news/2025-04-10-container-builder-token-migration/), this PR:
- Replaces usage of the `CONTAINER_BUILDER_TOKEN` with the `BASE_CONTAINER_IMAGE_READER_DEPENDABOT` token in dependabot configurations

Parent Issue: https://github.com/github/vuln-mgmt-eng/issues/5932