### PR TITLE
fix: correct post_call TypeVar in annotate_logs overload + docstring typos

### DIFF
--- a/annotated_logger/__init__.py
+++ b/annotated_logger/__init__.py
@@ -644,7 +644,7 @@ class AnnotatedLogger:
         *,
         success_info: bool = True,  # pragma: no mutate
         pre_call: PreCall[S2, P2] = None,
-        post_call: PostCall[S2, P2] = None,
+        post_call: PostCall[S2, P3] = None,
         _typing_self: Literal[False],
         _typing_requested: Literal[True],
         provided: Literal[True],

--- a/annotated_logger/plugins.py
+++ b/annotated_logger/plugins.py
@@ -24,7 +24,7 @@ class BasePlugin:
     def uncaught_exception(
         self, exception: Exception, logger: AnnotatedAdapter
     ) -> AnnotatedAdapter:
-        """Handle an uncaught excaption."""
+        """Handle an uncaught exception."""
         if "success" not in logger.filter.annotations:
             logger.annotate(success=False)
         if "exception_title" not in logger.filter.annotations:
@@ -68,7 +68,7 @@ class RenamerPlugin(BasePlugin):
         """Exception for a field that is supposed to be renamed, but is not present."""
 
     def __init__(self, *, strict: bool = False, **kwargs: str) -> None:
-        """Store the list of names to rename and pre/post fixs."""
+        """Store the list of names to rename and pre/post fixes."""
         self.targets = kwargs
         self.strict = strict
 
@@ -104,7 +104,7 @@ class NameAdjusterPlugin(BasePlugin):
     """Plugin that prevents name collisions with splunk field names."""
 
     def __init__(self, names: list[str], prefix: str = "", postfix: str = "") -> None:
-        """Store the list of names to rename and pre/post fixs."""
+        """Store the list of names to rename and pre/post fixes."""
         self.names = names
         self.prefix = prefix
         self.postfix = postfix


### PR DESCRIPTION
Hi! Found a few small issues while browsing the source:

## 1. Inconsistent `post_call` TypeVar in one overload

In `annotated_logger/__init__.py`, all 21 of the `@overload` definitions of `annotate_logs` declare:

```python
post_call: PostCall[S2, P3] = None,
```

…and the implementation signature at the bottom also uses `PostCall[S2, P3]`. But the "Instance False, Requested True, Provided True" overload (line ~647) accidentally uses `P2`:

```python
post_call: PostCall[S2, P2] = None,  # <-- inconsistent
```

This makes the overload's type signature disagree with the actual function (and with every sibling overload), which breaks type inference for users decorating a bare function that both requests a logger and accepts one passed in. Fix is to make it `P3` for consistency.

## 2. Two docstring typos in `plugins.py`

- `BasePlugin.uncaught_exception`: "Handle an uncaught excaption." → "Handle an uncaught exception."
- `RenamerPlugin.__init__` and `NameAdjusterPlugin.__init__`: "pre/post fixs" → "pre/post fixes"

All changes are local and don't alter runtime behavior. — Sent via @AmSach bot