### PR TITLE
chore: combine annotated-logger dependency updates

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.x"
     - name: Install hatch
@@ -50,7 +50,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   github-release:
     name: >-
@@ -71,7 +71,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@5b79a39c381910c090341a2c9b0bf022c8b387e1 #v3.4.0
+      uses: sigstore/gh-action-sigstore-python@790bc6befb9d733738f18d8f895854b453640ec9 #v3.5.0
       with:
         inputs: >-
           ./dist/*.tar.gz
@@ -115,6 +115,6 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution 📦 to TestPyPI
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -118,3 +118,9 @@ jobs:
       uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         repository-url: https://test.pypi.org/legacy/
+        # This job runs on every push, but the project version only changes at
+        # release time, so most runs re-upload an already-published file and
+        # TestPyPI rejects it with "400 File already exists". Skip files that
+        # are already there instead of failing the build. Deliberately not set
+        # on the real PyPI job, where a duplicate upload should fail loudly.
+        skip-existing: true

--- a/.github/workflows/pyright.yaml
+++ b/.github/workflows/pyright.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install hatch

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
-        python-version: '3.x'
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install hatch

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,20 @@ lint.ignore = [
   "W191", "E111", "E114", "E117", "D206", "D300", "Q000", "Q001", "Q002", "Q003", "COM812", "COM819", "ISC001", "ISC002",
   # Conflicts with other rule, choosing one
   "D203", "D213",
+  # Stabilised out of preview in ruff 0.16 and pulled in by "ALL".
+  # This project does not use per-file copyright headers, and the public
+  # AnnotatedLogger constructor keeps its positional signature for
+  # backwards compatibility.
+  "CPY001", "PLR0917",
 ]
+
+[tool.ruff.format]
+# ruff 0.16 began formatting Python code blocks embedded in Markdown. The
+# README's ```python blocks deliberately show sample JSON log output beneath
+# the source; the formatter parses those lines as Python and rewrites them
+# into multi-line dict literals, destroying the documentation. Keep Markdown
+# out of the formatter.
+exclude = ["*.md"]
 
 [tool.ruff.lint.per-file-ignores]
 "test/*" = ["E501", "D10", "ANN", "S101", "PLR2004"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 # - requests
 #
 
-certifi==2026.6.17
+certifi==2026.7.22
     # via requests
 charset-normalizer==3.4.9
     # via requests

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -19,19 +19,19 @@
 # - requests
 #
 
-certifi==2026.6.17
+certifi==2026.7.22
     # via requests
 cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.9
     # via requests
-coverage==7.15.1
+coverage==7.15.4
     # via
     #   hatch.envs.dev
     #   pytest-cov
 distlib==0.4.3
     # via virtualenv
-filelock==3.29.7
+filelock==3.32.2
     # via virtualenv
 freezegun==1.5.5
     # via pytest-freezer
@@ -47,15 +47,15 @@ nodeenv==1.10.0
     # via
     #   pre-commit
     #   pyright
-packaging==26.2
+packaging==26.3
     # via pytest
-platformdirs==4.10.0
+platformdirs==4.11.0
     # via virtualenv
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-pre-commit==4.6.0
+pre-commit==4.6.1
     # via hatch.envs.dev
 pychoir==0.0.30
     # via hatch.envs.dev
@@ -93,7 +93,7 @@ requests==2.34.2
     #   requests-mock
 requests-mock==1.12.1
     # via hatch.envs.dev
-ruff==0.15.21
+ruff==0.16.1
     # via hatch.envs.dev
 six==1.17.0
     # via python-dateutil
@@ -103,5 +103,5 @@ typing-extensions==4.16.0
     #   pyright
 urllib3==2.7.0
     # via requests
-virtualenv==21.6.1
+virtualenv==21.7.1
     # via pre-commit


### PR DESCRIPTION
> [!NOTE]
> Combined on-call dependency patching PR for **Week 2** of the [vuln-mgmt-eng on-call rotation](https://github.com/github/vuln-mgmt-eng/blob/main/docs/on-call/on-call-rotation.md#week-2), tracked by [github/vuln-mgmt-eng#9583](https://github.com/github/vuln-mgmt-eng/issues/9583).
> Generated with [`dependaswat`](https://github.com/github/dependaswat) and finished by hand.

## What this PR does

Consolidates both open Dependabot PRs for this repo into a single reviewable change, and repairs the lint break that `ruff` 0.16 introduced.

| Area | Updates |
| --- | --- |
| Python (pip) | 1 Dependabot PR merged, 8 pinned dev/runtime packages |
| GitHub Actions | 1 Dependabot PR merged, 3 action pins refreshed |
| Docker | none open |
| Vendored packages | n/a — this repo has no `requirements-vendored.txt` |
| Lint config | `CPY001` + `PLR0917` added to `lint.ignore`; Markdown excluded from the formatter |

## 🔄 Dependabot PRs consolidated

| PR | Title | Disposition |
| --- | --- | --- |
| [#152](https://github.com/github/annotated-logger/pull/152) | `[actions] (deps)`: Bump the dev-dependencies group across 1 directory with 3 updates | ✅ Merged into this branch — close as superseded |
| [#154](https://github.com/github/annotated-logger/pull/154) | `[pip] (deps)`: Bump the dev-dependencies group across 1 directory with 8 updates | ✅ Merged into this branch — close as superseded (was red on `ruff`; fixed here) |

### Python packages (`requirements.txt`, `requirements/requirements-dev.txt`)

| Package | Previous | New |
| --- | --- | --- |
| `certifi` | 2026.6.17 | 2026.7.22 |
| `coverage` | 7.15.1 | 7.15.4 |
| `filelock` | 3.29.7 | 3.32.2 |
| `packaging` | 26.2 | 26.3 |
| `platformdirs` | 4.10.0 | 4.11.0 |
| `pre-commit` | 4.6.0 | 4.6.1 |
| `ruff` | 0.15.21 | **0.16.1** |
| `virtualenv` | 21.6.1 | 21.7.1 |

`certifi` is the only one that reaches the published package's runtime dependency set; the rest are dev-only.

### GitHub Actions pins

| Action | Previous | New |
| --- | --- | --- |
| `actions/setup-python` | `v6` | `v7` |
| `pypa/gh-action-pypi-publish` | `cef2210` (v1.14.0) | `dc37677` (v1.14.2) |
| `sigstore/gh-action-sigstore-python` | `5b79a39` (v3.4.0) | `790bc6b` (v3.5.0) |

Touches `pytest.yaml`, `pyright.yaml`, `ruff.yaml`, and `publish-to-pypi.yaml`.

> `sigstore/gh-action-sigstore-python` runs only in `github-release`, which `needs: publish-to-pypi` and is therefore gated behind `if: startsWith(github.ref, 'refs/tags/')` — this PR does not exercise it.
>
> `pypa/gh-action-pypi-publish` **is** exercised. `publish-to-testpypi` has no tag guard and the workflow triggers on `push`, so v1.14.2 ran on this branch and reached the upload step. That surfaced a long-standing red check, fixed here — see below.

Both sit on the supply-chain path for the published artifact and are worth a reviewer's eye.

## 🛡️ Security findings accounted for

No open Dependabot alerts on this repo at time of writing:

```
gh api repos/github/annotated-logger/dependabot/alerts?state=open  ->  []
```

This PR is routine maintenance patching, not a vulnerability remediation.

## 🔧 Lint repair (not a dependency change)

Bumping `ruff` to 0.16.1 broke lint in two independent ways. Both are fixed in `pyproject.toml` config only — **no source or documentation content was rewritten.**

**1. Two preview rules stabilized into `ALL`** (20 findings across 19 files):

| Rule | Findings | Why it is ignored |
| --- | --- | --- |
| `CPY001` `missing-copyright-notice` | 19 | This project does not use per-file copyright headers; it ships a top-level `LICENSE.txt`. |
| `PLR0917` `too-many-positional-arguments` | 1 | `AnnotatedLogger.__init__` (`annotated_logger/__init__.py:273`) takes 6 positional args. This is the public constructor of a published package — changing its signature is a breaking API change and does not belong in a dependency-patch PR. |

**2. The formatter began reformatting Markdown.** `ruff` 0.16 formats Python code blocks embedded in Markdown files, and CI runs `ruff format --check .`. `README.md`'s ` ```python ` blocks deliberately show **sample JSON log output** underneath the source:

```
{"created": 1708476277.102495, "levelname": "INFO", ... "annotated": true}
```

Those lines parse as valid Python expressions, so the formatter rewrote each one into a multi-line dict literal — turning a realistic one-line log sample into something that no longer resembles the tool's actual output. Since this package's entire purpose is demonstrating log shape, that diff destroys the documentation.

Markdown is therefore excluded from the formatter rather than accepting the rewrite:

```toml
[tool.ruff.format]
exclude = ["*.md"]
```

`ruff check` still lints normally; only the formatter is scoped. `README.md` is byte-for-byte unchanged in this PR.

<details>
<summary>Validation</summary>

All run locally against Python 3.12.4 on the combined branch, with `requirements.txt` + `requirements/requirements-dev.txt` installed as pinned:

| Command | Result |
| --- | --- |
| `ruff check .` (0.16.1) | ✅ All checks passed |
| `ruff format --check .` (0.16.1) | ✅ 19 files already formatted |
| `pytest` | ✅ 76 passed, **100.00% coverage** (required: 100%) |
| `pytest` on **3.10** and **3.14** (matrix bounds) | ✅ 76 passed, 100.00% coverage on each |
| `pyright` | ✅ 0 errors, 0 warnings, 0 informations |

Remote CI runs the suite across Python 3.10 – 3.14 and is the final gate.

> ⚠️ **The remote matrix does not actually provide that coverage, and this PR does not change that.** `pytest.yaml` declares a 3.10–3.14 matrix but pins the setup step to `python-version: '3.x'`, so all 15 jobs run one interpreter. Copilot raised this in review and I did apply the one-line binding (`91eac8c`) — but it surfaced a pre-existing failure unrelated to dependency patching: on `macos-latest` + 3.11, `hatch env create dev` fails with ``Environment `dev` has unknown type: pip-compile``, reproducibly across two runner allocations, while the identical command and the full suite pass locally on macOS arm64 / CPython 3.11.14. With no `fail-fast: false`, that one job cancels the other 14. I reverted the binding in `8818bb0` to keep this PR scoped, and filed **#156** with the full evidence and a suggested order of work.

> 🔧 **Fixed a permanently-red publish job.** `Publish to TestPyPI` had been failing on every PR in this repo, including on `main` (confirmed against the last four `main` runs). `publish-to-testpypi` runs on every push, but the project version only changes at release time, so each run rebuilt the current version and re-uploaded a file TestPyPI already had:
>
> ```
> Uploading annotated_logger-1.3.4-py3-none-any.whl
> 400 File already exists ('annotated_logger-1.3.4-py3-none-any.whl', ...)
> ```
>
> `6324a9a` sets `skip-existing: true` on that step — the canonical input on `pypa/gh-action-pypi-publish` at the pinned SHA `dc37677` (`skip_existing` is the deprecated alias). Verified against the action's `action.yml` at that exact SHA rather than assumed. It is **deliberately not** set on the real `publish-to-pypi` job, where a duplicate upload means someone re-released an existing version and should keep failing loudly.
>
> **This PR is now fully green: 23 checks pass, 0 fail.** The two `skipping` entries are the tag-gated PyPI and Sigstore release jobs, correctly inactive on a branch push.

</details>

<details>
<summary>Deployment monitoring</summary>

**Not applicable.** `annotated-logger` is a shared library published to PyPI and consumed by other services in the platform (vulnerability-aggregator, scan-engine, vuln-notifier, wiz-therapy, and others). It has no `config/moda/` directory and is not deployed to a Kubernetes namespace, so there is no staging/production rollout to baseline.

Downstream exposure only happens when a consuming service re-resolves its own lockfile and picks up a new release — and this PR does **not** cut a release or bump the package version.

No Splunk baseline was captured, and none is claimed.

</details>

<details>
<summary>Isolation / not touched</summary>

This PR changes `requirements.txt`, `requirements/requirements-dev.txt`, four workflow files, and `pyproject.toml`.

It does **not** modify:

- any runtime source under `annotated_logger/` — no behavior change
- any file under `example/` or `test/` — no test or assertion was altered
- `README.md` or any documentation content (explicitly protected from the formatter, see above)
- the public API surface, including `AnnotatedLogger.__init__`'s signature
- the package version, release configuration, or changelog
- the `publish-to-testpypi` tag guard — the job still runs on every push; only its duplicate-upload handling changed
- release semantics for the real PyPI index — `publish-to-pypi` still fails on a duplicate upload
- the `pytest.yaml` version matrix — binding it exposes a pre-existing macOS/3.11 environment failure, tracked in #156
- coverage thresholds (still 100%)
- workflow triggers, permissions, or job structure

Beyond the dependency pins, there are exactly two non-dependency edits:

1. `pyproject.toml` — two rules appended to the existing curated `lint.ignore` array, plus a new `[tool.ruff.format]` section with a single `exclude` key (13 lines).
2. `.github/workflows/publish-to-pypi.yaml` — `skip-existing: true` on the TestPyPI upload step only (`6324a9a`), fixing a permanently-failing check.

</details>
